### PR TITLE
QOL (drag/drop), UI & code style improvements

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -3,50 +3,33 @@
   <meta charset="UTF-8" name="viewport" content="width=device-width">
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <title>MercuryPlayer</title>
-  <style>html{background:black;font-family:Meiryo}select,option{-moz-font:-moz-pull-down-menu;font-family:Meiryo}canvas{position:fixed;left:0;top:0;height:100vh;width:100vw}</style>
-  <style>video{position:fixed;mask-size:100%;mask-image:url('data:image/svg+xml,%3Csvg height%3D"2" width%3D"2" version%3D"1.1" xmlns%3D"http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg"%3E%3Cellipse style%3D"fill%3A%23000" cx%3D"1" cy%3D"1" rx%3D"1" ry%3D"1"%2F%3E%3C%2Fsvg%3E')}</style>
-  <style>.hide-control div:not(.no-hide) {opacity:0}</style>
-  <style>.long-audio audio {width:1000px}</style>
-  <style>
-    .bgm,.bgm *{opacity:1 !important}
-    .bgm{display:flex;height:40px;line-height:40px;background:rgba(30,30,30,0.7);width:500px;text-align:center}
-    .bgm svg{fill:currentColor}
-    .bgm *:hover>svg{fill:#48a0f7}
-    .bgm *:hover:active>svg{fill:#2d89e6}
-    .bgm>*{flex:none}
-    .bgm .btn{width:40px;padding:3px 0}
-    .bgm .progress{flex:1}
-    .bgm .progress input[type=range]{height:40px;margin:0;padding:0;width:100%}
-    .bgm .duration{width:80px;font-family:Arial;font-size:14px}
-    .bgm .duration .duration-grey{color:gray}
-    .bgm .volume{width:30px;padding:3px 0}
-    .bgm .volume_slider{width:50px;padding:0 15px 0 5px}
-    .bgm .volume_slider input[type=range]{height:40px;margin:0;padding:0;width:100%}
-    .long-audio .bgm {width:1000px;max-width:calc(100vw - 16px)}
-  </style>
-  <style>
-    .github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}
-    @keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}
-    @media (max-width:500px){.github-corner:hover .octo-arm{animation:none}
-    .github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
-    .github-corner {position:absolute; top:0; border:0; right:0; z-index:10}
-  </style>
+  <link rel="stylesheet" href="main.css">
 </head>
 <body ontouchstart>
 <a href="https://github.com/yellowberryHN/MercuryPlayer" class="github-corner" aria-label="View source on GitHub"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#fff; color:#151513" aria-hidden="true"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a>
 <video src preload id="bga"></video>
 <canvas id="canvas"></canvas>
-<div style="position:fixed;left:5px;bottom:5px;color:white" class="no-hide">
-  <div>SE Volume: <select id="se_volume"></select>　<input id="se_file" name="mer_se_file" type="file" accept="audio/*" placeholder="sound effect file path..."/></div>
-  <div class="no-hide"><label><input type="checkbox" id="toggle_ui" autocomplete="off"><span>Hide UI</span></label></div>
-  <div><label><input type="checkbox" id="toggle_long_audio" autocomplete="off"><span>Long audio</span></label></div>
-  <div style="white-space:pre-wrap" id="stats"></div>
-  <div style="display:none"><select id="music_select"></select><br><select id="diffi_select"><option value="0">Normal</option><option value="1">Hard</option><option value="2" selected>Expert</option><option value="3">Inferno</option></select>　<input type="button" value="Load" onclick="loadUsingSelect()"></div>
-  <div><input id="music_file" name="mer_file" type="file" accept=".mer" value=".mer path..."/>　<input id="bgm_file" name="mer_bgm_file" type="file" accept="audio/*" placeholder="sound file path..."/>　<input type="button" value="Load" onclick="loadUsingFile()"></div>
-  <input type="range" min="5" max="60" step="1" value="38" autocomplete="off" id="speed_input"><span id="speed_val">3.8</span><br>
+<div style="position: fixed; left: 5px; bottom: 5px; color: white;" class="no-hide">
+  <div style="white-space: pre-wrap;" id="stats"></div>
+  <div style="display: none;"><select id="music_select"></select><br><select id="diffi_select"><option value="0">Normal</option><option value="1">Hard</option><option value="2" selected>Expert</option><option value="3">Inferno</option></select>　<input type="button" value="Load" onclick="loadUsingSelect()"></div>
+
+  <div>SE Volume: <select id="se_volume"></select></div>
+  <div>SE: <input id="se_file" name="mer_se_file" type="file" accept="audio/*" placeholder="sound effect file path..."/></div>
+  <div>Notes: <input id="music_file" name="mer_file" type="file" accept=".mer" value=".mer path..."/></div>
+  <div>BGM: <input id="bgm_file" name="mer_bgm_file" type="file" accept="audio/*" placeholder="sound file path..."/></div>
+  <div>Speed: <input type="range" min="5" max="60" step="1" value="38" autocomplete="off" id="speed_input"><span id="speed_val">3.8</span></div>
+
+  <div class="no-hide">
+    <span><label><input type="checkbox" id="toggle_ui" autocomplete="off">Hide UI</label></span>
+    <span><label><input type="checkbox" id="toggle_long_audio" autocomplete="off">Long audio</label></span>
+  </div>
+
+  <input id="loadbtn" type="button" value="LOAD" onclick="loadUsingFile()">
+  &nbsp;
   <input type="button" value="play" onclick="play()">
   <input type="button" value="pause" onclick="pause()">
-  <input type="button" value="stop" onclick="stop()"><br>
+  <input type="button" value="stop" onclick="stop()">
+  <br>
   <!--<audio preload id="bgm" controls></audio>-->
   <div class="bgm no-hide" id="bgm_custom"></div>
 </div>

--- a/main.css
+++ b/main.css
@@ -1,0 +1,123 @@
+html {
+    background: black;
+    font-family: Meiryo, Helvetica, Arial, sans-serif;
+}
+select, option {
+    -moz-font: -moz-pull-down-menu;
+    font-family: Meiryo, Helvetica, Arial, sans-serif;
+}
+canvas {
+    position: fixed;
+    left: 0;
+    top: 0;
+    height: 100vh;
+    width: 100vw;
+}
+video {
+    position: fixed;
+    mask-size: 100%;
+    mask-image: url('data:image/svg+xml,%3Csvg height%3D"2" width%3D"2" version%3D"1.1" xmlns%3D"http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg"%3E%3Cellipse style%3D"fill%3A%23000" cx%3D"1" cy%3D"1" rx%3D"1" ry%3D"1"%2F%3E%3C%2Fsvg%3E');
+}
+input {
+    padding-top: 0.5px;
+    padding-bottom: 0.5px;
+}
+.hide-control div:not(.no-hide) {
+    opacity: 0;
+}
+.long-audio audio {
+    width: 1000px;
+}
+
+.bgm, .bgm * {
+    opacity: 1 !important;
+}
+.bgm {
+    display: flex;
+    height: 40px;
+    line-height: 40px;
+    background: rgba(30, 30, 30, 0.7);
+    width: 500px;
+    text-align: center;
+}
+.bgm svg {
+    fill: currentColor;
+}
+.bgm *:hover > svg {
+    fill: #48a0f7;
+}
+.bgm *:hover:active > svg {
+    fill: #2d89e6;
+}
+.bgm > * {
+    flex: none;
+}
+.bgm .btn {
+    width: 40px;
+    padding: 3px 0;
+}
+.bgm .progress {
+    flex: 1;
+}
+.bgm .progress input[type="range"] {
+    height: 40px;
+    margin: 0;
+    padding: 0;
+    width: 100%;
+}
+.bgm .duration {
+    width: 80px;
+    font-family: Arial;
+    font-size: 14px;
+}
+.bgm .duration .duration-grey {
+    color: gray;
+}
+.bgm .volume {
+    width: 30px;
+    padding: 3px 0;
+}
+.bgm .volume_slider {
+    width: 50px;
+    padding: 0 15px 0 5px;
+}
+.bgm .volume_slider input[type="range"] {
+    height: 40px;
+    margin: 0;
+    padding: 0;
+    width: 100%;
+}
+.long-audio .bgm {
+    width: 1000px;
+    max-width: calc(100vw - 16px);
+}
+
+.github-corner:hover .octo-arm {
+    animation: octocat-wave 560ms ease-in-out;
+}
+@keyframes octocat-wave {
+    0%, 100% {
+        transform: rotate(0);
+    }
+    20%, 60% {
+        transform: rotate(-25deg);
+    }
+    40%, 80% {
+        transform: rotate(10deg);
+    }
+}
+@media (max-width: 500px) {
+    .github-corner:hover .octo-arm {
+        animation: none;
+    }
+    .github-corner .octo-arm {
+        animation: octocat-wave 560ms ease-in-out;
+    }
+}
+.github-corner {
+    position: absolute;
+    top: 0;
+    border: 0;
+    right: 0;
+    z-index: 10;
+}

--- a/main.js
+++ b/main.js
@@ -189,6 +189,39 @@ if (window.location.protocol !== "file:") {
   })
 }
 
+document.addEventListener('dragover', (e) => {
+  e.preventDefault()
+});
+document.addEventListener('drop', (e) => {
+  e.preventDefault()
+  var files = e.dataTransfer.files;
+  for (var i = 0; i < files.length; i++) {
+    var ext = files[i]['name'].split('.').pop();
+
+    const dT = new DataTransfer();
+    dT.items.add(e.dataTransfer.files[i]);
+
+    switch (ext) {
+      case 'wav':
+        document.getElementById('se_file').files = dT.files;
+        se_file_load(); // immediately load
+        break;
+      case 'mer':
+        document.getElementById('music_file').files = dT.files;
+        break;
+      case 'mp3':
+        document.getElementById('bgm_file').files = dT.files;
+        break;
+      default:
+        document.getElementById('bgm_file').files = dT.files;
+        break;
+    }
+  }
+  if (files.length >= 2) { // wav already loaded?
+    loadUsingFile();
+  }
+});
+
 function loadUsingSelect() {
   const id = music_select.value | 0
   const diffi = diffi_select.value | 0
@@ -208,7 +241,7 @@ function loadUsingFile() {
     bgmFileName = 'file'
     setBgm(URL.createObjectURL(bgm_file.files[0]))
   } else {
-    alert('choose file')
+    alert('Please choose remaining files.')
   }
 }
 music_select.addEventListener('change', e => {
@@ -564,8 +597,8 @@ toggle_long_audio.addEventListener('input', () => {
 setInterval(() => {
   if (stats.childNodes.length == 0) stats.appendChild(document.createTextNode(''))
   stats.childNodes[0].nodeValue = [
-    `frame draw: ${drawCount.frame}`,
-    `frame actual draw: ${drawCount.actualFrame}`,
+    `Frame draw: ${drawCount.frame}`,
+    `Frame actual draw: ${drawCount.actualFrame}`,
   ].join('\n')
   drawCount.frame = 0
   drawCount.actualFrame = 0
@@ -1345,7 +1378,7 @@ se_volume.addEventListener('change', () => {
   gain.gain.value = se_volume.value / 100
 })
 
-se_file.addEventListener('change', () => {
+function se_file_load() {
   const reader = new FileReader()
   reader.readAsArrayBuffer(se_file.files[0])
   reader.onload = e => {
@@ -1357,7 +1390,9 @@ se_file.addEventListener('change', () => {
       }
     }, e => console.error(e))
   }
-})
+}
+
+se_file.addEventListener('change', se_file_load)
 
 class BgmController {
   __playSvg = "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 16 16\" width=\"16\" height=\"16\" fill=\"context-fill\" fill-opacity=\"context-fill-opacity\"><path d=\"m2.992 13.498 0-10.996a1.5 1.5 0 0 1 2.245-1.303l9.621 5.498a1.5 1.5 0 0 1 0 2.605L5.237 14.8a1.5 1.5 0 0 1-2.245-1.302z\"/></svg>"


### PR DESCRIPTION
- Added 3-file (or fewer) file drag & drop functionality. Detects `.wav`, `.mer`, and `.mp3` files for the three input fields and puts them in the correct places
  - Can be dropped anywhere on the page
  - "Load" button is automatically pressed & chart appears, no need to manually click it if you drag in all required files
![GIF](https://github.com/yellowberryHN/MercuryPlayer/assets/7245874/1f2b93c9-6a66-4369-8d4b-2b00159b66f2)
- Tweak UI on main page – rearrange elements to push into corner, correctly fallback to sans-serif font
- Bring CSS  `<style>` tags from `index.htm` out into separate, formatted file (`main.css`)